### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.8 as base
+FROM python:3.8-slim-buster as base
 
 # Setup ENV variables here (if needed in the future)
 
@@ -15,8 +15,11 @@ COPY Pipfile.lock .
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
 
 
-FROM base as runtime
-
+FROM base
+# install postgres driver
+RUN apt update && \
+    apt install libpq-dev -y && \
+    rm -rf /var/lib/apt/lists/*
 # Copy virtual env from python-deps stage
 COPY --from=python-deps /.venv /.venv
 ENV PATH="/.venv/bin:$PATH"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,7 @@ services:
     build:
       context: .
       dockerfile: dev.Dockerfile
+    restart: on-failure
     volumes:
       - ./kipubot:/bot/kipubot
     env_file:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,10 +12,12 @@ services:
       dockerfile: dev.Dockerfile
     restart: on-failure
     volumes:
-      - ./kipubot:/bot/kipubot
+      - kipubot_db:/bot/kipubot
     env_file:
       - .env
     environment:
       - DATABASE_URL=postgresql://username:password@database:5432
     depends_on:
       - database
+volumes:
+  kipubot_db:


### PR DESCRIPTION
- Change the base image from python:3.8 to slim-buster variant, and install missing library separately in runtime-phase. Image size went from 1.29GB down to 484MB

- Fix dev environment crash before first reload, that was caused by the slow postgres initialization. This was fixed with adding restart-flag to bot-service in docker-compose.dev.yml

- Move development database to a separate volume rather than bind it to a folder.